### PR TITLE
feat: Add manual login flow for headless environments

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -13,6 +13,7 @@ import { resetTokenManager } from '../google/token-manager.js'
 interface LoginOptions {
   noBrowser?: boolean
   port?: number
+  manual?: boolean
 }
 
 export async function loginCommand(options: LoginOptions): Promise<void> {
@@ -25,7 +26,8 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
   
   const result = await startOAuthFlow({
     noBrowser: options.noBrowser,
-    port: options.port
+    port: options.port,
+    manual: options.manual
   })
   
   if (result.success) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ program
   .command('login')
   .description('Authenticate with Google (adds a new account)')
   .option('--no-browser', 'Do not open browser, print URL instead')
+  .option('--manual', 'Manual login flow (copy-paste URL)')
   .option('-p, --port <port>', 'Port for OAuth callback server', parseInt)
   .action(loginCommand)
 


### PR DESCRIPTION
This PR adds a --manual flag to the login command. This allows users to authenticate in headless environments (like SSH sessions or Docker containers) where opening a browser locally is not possible.

Instead of failing to open a browser, the tool will:
1. Print the auth URL to the console.
2. Ask the user to visit it on another machine.
3. Prompt the user to paste the full redirect URL (including the code).
4. Complete the authentication flow using the pasted code.

This solves the issue for users running antigravity-usage on remote servers.