### PR TITLE
feat: exclude autocomplete models (Gemini 2.5) from default quota view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^2.1.8"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ program
   .option('--all', 'Show quota for all accounts')
   .option('-a, --account <email>', 'Show quota for specific account')
   .option('--refresh', 'Force refresh (ignore cache)')
+  .option('--all-models', 'Include autocomplete models (Gemini 2.5) in quota display')
   .action(quotaCommand)
 
 // Accounts command with subcommands

--- a/src/quota/types.ts
+++ b/src/quota/types.ts
@@ -18,6 +18,7 @@ export interface ModelQuotaInfo {
   isExhausted: boolean
   resetTime?: string
   timeUntilResetMs?: number
+  isAutocompleteOnly?: boolean
 }
 
 export interface PromptCreditsInfo {

--- a/test/google/parser.test.ts
+++ b/test/google/parser.test.ts
@@ -44,7 +44,7 @@ describe('parseQuotaSnapshot', () => {
 
     expect(snapshot.method).toBe('google')
     expect(snapshot.timestamp).toBeDefined()
-    
+
     // Prompt credits
     expect(snapshot.promptCredits).toBeDefined()
     expect(snapshot.promptCredits?.available).toBe(450)
@@ -54,12 +54,12 @@ describe('parseQuotaSnapshot', () => {
 
     // Models - sorted alphabetically
     expect(snapshot.models).toHaveLength(2)
-    
+
     // Claude comes before Gemini alphabetically
     expect(snapshot.models[0].label).toBe('Claude 3.5 Sonnet')
     expect(snapshot.models[0].modelId).toBe('claude-3.5-sonnet')
     expect(snapshot.models[0].isExhausted).toBe(true)
-    
+
     expect(snapshot.models[1].label).toBe('Gemini 2.0 Flash')
     expect(snapshot.models[1].modelId).toBe('gemini-2.0-flash')
     expect(snapshot.models[1].remainingPercentage).toBe(0.85)
@@ -157,7 +157,11 @@ describe('parseQuotaSnapshot', () => {
     const snapshot = parseQuotaSnapshot({}, modelsResponse)
 
     // Only gemini-2.5-pro should be included
-    expect(snapshot.models).toHaveLength(1)
-    expect(snapshot.models[0].label).toBe('Gemini 2.5 Pro')
+    expect(snapshot.models.some(m => m.modelId === 'chat_12345')).toBe(false)
+    expect(snapshot.models.some(m => m.modelId === 'tab_flash')).toBe(false)
+
+    const gemini25 = snapshot.models.find(m => m.modelId === 'gemini-2.5-pro')
+    expect(gemini25).toBeDefined()
+    expect(gemini25?.isAutocompleteOnly).toBe(true)
   })
 })

--- a/test/local/local-parser.test.ts
+++ b/test/local/local-parser.test.ts
@@ -40,7 +40,7 @@ describe('local-parser', () => {
         usedPercentage: 0.1,
         remainingPercentage: 0.9
       })
-      
+
       expect(snapshot.models).toHaveLength(1)
       expect(snapshot.models[0]).toEqual({
         modelId: 'gemini-2.0',
@@ -48,7 +48,8 @@ describe('local-parser', () => {
         remainingPercentage: 0.8,
         isExhausted: false,
         resetTime: '2026-01-15T12:00:00Z',
-        timeUntilResetMs: 3600000
+        timeUntilResetMs: 3600000,
+        isAutocompleteOnly: false
       })
     })
 

--- a/test/quota/format.test.ts
+++ b/test/quota/format.test.ts
@@ -10,7 +10,7 @@ describe('printQuotaJson', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { })
   })
 
   afterEach(() => {
@@ -37,7 +37,7 @@ describe('printQuotaTable', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { })
   })
 
   afterEach(() => {
@@ -69,7 +69,7 @@ describe('printQuotaTable', () => {
 
     // Verify console was called multiple times (header, table)
     expect(consoleSpy.mock.calls.length).toBeGreaterThan(2)
-    
+
     // Check that some expected content is in the output
     const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n')
     expect(allOutput).toContain('Antigravity')
@@ -94,5 +94,54 @@ describe('printQuotaTable', () => {
 
     const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n')
     expect(allOutput).toContain('EXHAUSTED')
+  })
+
+  it('should filter autocomplete models by default', () => {
+    const snapshot: QuotaSnapshot = {
+      timestamp: '2026-01-14T12:00:00.000Z',
+      method: 'google',
+      models: [
+        {
+          label: 'Coding Model',
+          modelId: 'coding',
+          isExhausted: false,
+          isAutocompleteOnly: false
+        },
+        {
+          label: 'Autocomplete Model',
+          modelId: 'gemini-2.5-flash',
+          isExhausted: false,
+          isAutocompleteOnly: true
+        }
+      ]
+    }
+
+    printQuotaTable(snapshot)
+
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n')
+    expect(allOutput).toContain('Coding Model')
+    expect(allOutput).not.toContain('Autocomplete Model')
+    // The tip is shown when visibleModels.length is 0 but there ARE autocomplete models.
+    // In this test, visibleModels.length is 1 (Coding Model).
+  })
+
+  it('should show autocomplete models when allModels option is true', () => {
+    const snapshot: QuotaSnapshot = {
+      timestamp: '2026-01-14T12:00:00.000Z',
+      method: 'google',
+      models: [
+        {
+          label: 'Autocomplete Model',
+          modelId: 'gemini-2.5-flash',
+          isExhausted: false,
+          isAutocompleteOnly: true
+        }
+      ]
+    }
+
+    printQuotaTable(snapshot, { allModels: true })
+
+    const allOutput = consoleSpy.mock.calls.map(c => c[0]).join('\n')
+    expect(allOutput).toContain('Autocomplete Model')
   })
 })


### PR DESCRIPTION
## Changes
- Flag Gemini 2.5 models as autocomplete-only in parsers.
- Filter autocomplete models from default table displays and multi-account summaries.
- Add `--all-models` flag to include them in display.
- Implement visual N/A bar placeholder for coding models without percentage data.
- Add `docs/models.md` documentation.
- Update and add unit tests for filtering logic.

## Verification
- Ran `npm test` (184/184 passing).
- Manually verified CLI output for both detailed and summary views.