### PR TITLE
fix(local): improve Linux process detection and add port fallback

### DIFF
--- a/src/quota/service.ts
+++ b/src/quota/service.ts
@@ -107,8 +107,13 @@ async function fetchQuotaLocal(): Promise<QuotaSnapshot> {
   debug('service', `Found Antigravity process: PID ${processInfo.pid}`)
   
   // Step 2: Discover all listening ports (to find the connect port, not extension_server_port)
-  const ports = await discoverPorts(processInfo.pid)
-  
+  let ports = await discoverPorts(processInfo.pid)
+
+  if (ports.length === 0 && processInfo.extensionServerPort) {
+    debug('service', `Falling back to extension_server_port: ${processInfo.extensionServerPort}`)
+    ports = [processInfo.extensionServerPort]
+  }
+
   if (ports.length === 0) {
     throw new PortDetectionError()
   }


### PR DESCRIPTION
## Summary
Fixes Linux local-mode failures in `antigravity-usage --method local` caused by:
1. False-positive process detection (installer shell script matched as server process).
2. Port detection returning empty in some environments where PID mapping from `ss/netstat` is unavailable.

## Changes
- `src/local/process-detector.ts`
  - Tightened Unix candidate filtering:
    - Require `antigravity`.
    - Skip installer script signatures (`server installation script`).
    - Require stronger server signals (`language-server`, `lsp`, `--csrf_token`, `--extension_server_port`, `exa.language_server_pb`).
- `src/quota/service.ts`
  - If PID-based port discovery returns empty, fallback to parsed `processInfo.extensionServerPort`.

## Repro (before)
`antigravity-usage --debug --method local` selected installer shell process and failed with:
- `Could not detect Antigravity server port.`

## Result (after)
`antigravity-usage --debug --method local`:
- Detects actual `language_server_linux_x64` process.
- Finds/probes Connect endpoint successfully.
- Fetches and prints LOCAL quota snapshot.

## Validation
- `npm run typecheck`: pass
- `npm run build`: pass
- `npm test`: partially blocked in this environment due to cron-related EPERM in `test/wakeup/cron-installer.test.ts` (unrelated to changed files).

## Environment
Validated in WSL/Linux with Antigravity IDE server running.
