### PR TITLE
fix(local/windows): harden local endpoint and process selection

### DIFF
--- a/src/quota/service.ts
+++ b/src/quota/service.ts
@@ -107,8 +107,13 @@ async function fetchQuotaLocal(): Promise<QuotaSnapshot> {
   debug('service', `Found Antigravity process: PID ${processInfo.pid}`)
   
   // Step 2: Discover all listening ports (to find the connect port, not extension_server_port)
-  const ports = await discoverPorts(processInfo.pid)
-  
+  let ports = await discoverPorts(processInfo.pid)
+
+  if (ports.length === 0 && processInfo.extensionServerPort) {
+    debug('service', `Falling back to extension_server_port: ${processInfo.extensionServerPort}`)
+    ports = [processInfo.extensionServerPort]
+  }
+
   if (ports.length === 0) {
     throw new PortDetectionError()
   }

--- a/test/local/port-prober.test.ts
+++ b/test/local/port-prober.test.ts
@@ -1,147 +1,131 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { probeForConnectAPI } from '../../src/local/port-prober.js'
 import * as https from 'https'
 import * as http from 'http'
 import { EventEmitter } from 'events'
 
-// Mock http and https
 vi.mock('http')
 vi.mock('https')
+
+type MockPlan = {
+  statusCode?: number
+  error?: Error
+  body?: string
+}
+
+function applyModulePlan(module: { request: any }, plansByPort: Record<number, MockPlan>) {
+  module.request.mockImplementation((options: any, callback: any) => {
+    const req = new EventEmitter() as any
+    req.end = vi.fn()
+    req.write = vi.fn()
+    req.destroy = vi.fn()
+
+    const port = Number(options.port)
+    const plan = plansByPort[port] || { error: new Error('Connection refused') }
+
+    setTimeout(() => {
+      if (plan.error) {
+        req.emit('error', plan.error)
+        return
+      }
+
+      const res = new EventEmitter() as any
+      res.statusCode = plan.statusCode
+      res.resume = vi.fn()
+      callback(res)
+      if (plan.body) {
+        res.emit('data', Buffer.from(plan.body))
+      }
+      res.emit('end')
+    }, 0)
+
+    return req
+  })
+}
 
 describe('port-prober', () => {
   beforeEach(() => {
     vi.resetAllMocks()
   })
 
-  // Helper to mock request
-  function mockRequest(module: any, statusCode?: number, error?: Error, delay = 0) {
-    // Create a request object that is also an EventEmitter
-    const req = new EventEmitter() as any
-    req.end = vi.fn()
-    req.write = vi.fn() // Add write method for POST requests
-    req.destroy = vi.fn()
-    
-    module.request.mockImplementation((options: any, callback: any) => {
-      setTimeout(() => {
-        if (error) {
-          req.emit('error', error)
-        } else if (statusCode) {
-          const res = new EventEmitter() as any
-          res.statusCode = statusCode
-          res.resume = vi.fn()
-          callback(res)
-        }
-      }, delay)
-      
-      return req
-    })
-    
-    return req
-  }
+  it('accepts HTTPS Connect endpoint on 200', async () => {
+    applyModulePlan(https as any, { 42001: { statusCode: 200 } })
+    applyModulePlan(http as any, { 42001: { error: new Error('unused') } })
 
-  describe('probeForConnectAPI', () => {
-    it('should find HTTPS endpoint', async () => {
-      // Setup HTTPS to succeed with HTTP 200 (valid Connect RPC response)
-      mockRequest(https, 200)
-      // Setup HTTP to fail
-      mockRequest(http, undefined, new Error('Connection refused'))
-      
-      const result = await probeForConnectAPI([42001])
-      
-      expect(result).toEqual({
-        baseUrl: 'https://127.0.0.1:42001',
-        protocol: 'https',
-        port: 42001
-      })
-      
-      expect(https.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          hostname: '127.0.0.1',
-          port: 42001,
-          method: 'POST',
-          path: '/exa.language_server_pb.LanguageServerService/GetUnleashData',
-          rejectUnauthorized: false
-        }),
-        expect.any(Function)
-      )
+    const result = await probeForConnectAPI([42001])
+
+    expect(result).toEqual({
+      baseUrl: 'https://127.0.0.1:42001',
+      protocol: 'https',
+      port: 42001
+    })
+  })
+
+  it('accepts HTTPS Connect endpoint on 401 (auth required signal)', async () => {
+    applyModulePlan(https as any, { 42002: { statusCode: 401 } })
+    applyModulePlan(http as any, { 42002: { error: new Error('unused') } })
+
+    const result = await probeForConnectAPI([42002])
+
+    expect(result).toEqual({
+      baseUrl: 'https://127.0.0.1:42002',
+      protocol: 'https',
+      port: 42002
+    })
+  })
+
+  it('falls back to HTTP Connect endpoint when HTTPS probe fails', async () => {
+    applyModulePlan(https as any, { 42003: { error: new Error('SSL error') } })
+    applyModulePlan(http as any, { 42003: { statusCode: 200 } })
+
+    const result = await probeForConnectAPI([42003])
+
+    expect(result).toEqual({
+      baseUrl: 'http://127.0.0.1:42003',
+      protocol: 'http',
+      port: 42003
+    })
+  })
+
+  it('rejects HTTP mismatch response from HTTPS-only endpoint', async () => {
+    applyModulePlan(https as any, { 42004: { error: new Error('SSL error') } })
+    applyModulePlan(http as any, {
+      42004: {
+        statusCode: 400,
+        body: 'Client sent an HTTP request to an HTTPS server.'
+      }
     })
 
-    it('should fallback to HTTP if HTTPS fails', async () => {
-      // Setup HTTPS to fail
-      mockRequest(https, undefined, new Error('SSL Error'))
-      // Setup HTTP to succeed
-      mockRequest(http, 200)
-      
-      const result = await probeForConnectAPI([42001])
-      
-      expect(result).toEqual({
-        baseUrl: 'http://localhost:42001',
-        protocol: 'http',
-        port: 42001
-      })
+    const result = await probeForConnectAPI([42004])
+    expect(result).toBeNull()
+  })
+
+  it('rejects non-connect status codes', async () => {
+    applyModulePlan(https as any, { 42005: { statusCode: 404 } })
+    applyModulePlan(http as any, { 42005: { statusCode: 404 } })
+
+    const result = await probeForConnectAPI([42005])
+    expect(result).toBeNull()
+  })
+
+  it('tries multiple ports and returns first valid Connect endpoint', async () => {
+    applyModulePlan(https as any, {
+      3001: { error: new Error('refused') },
+      3002: { error: new Error('refused') },
+      3003: { statusCode: 200 }
+    })
+    applyModulePlan(http as any, {
+      3001: { statusCode: 404 },
+      3002: { statusCode: 404 },
+      3003: { error: new Error('unused') }
     })
 
-    it('should try multiple ports', async () => {
-      const ports = [1000, 2000, 3000]
-      
-      // HTTPS fails on all
-      mockRequest(https, undefined, new Error('Connection refused'))
-      
-      // HTTP succeeds only on 2000
-      vi.mocked(http.request).mockImplementation((options: any, callback: any) => {
-        const req = new EventEmitter() as any
-        req.end = vi.fn()
-        req.write = vi.fn() // Add write method
-        req.destroy = vi.fn()
-        
-        const port = Number(options.port)
-        
-        setTimeout(() => {
-          if (port === 2000) {
-            const res = new EventEmitter() as any
-            res.statusCode = 200
-            res.resume = vi.fn()
-            callback(res)
-          } else {
-            req.emit('error', new Error('Connection refused'))
-          }
-        }, 10)
-        
-        return req
-      })
-      
-      const result = await probeForConnectAPI(ports)
-      
-      expect(result).toEqual({
-        baseUrl: 'http://localhost:2000',
-        protocol: 'http',
-        port: 2000
-      })
-    })
+    const result = await probeForConnectAPI([3001, 3002, 3003])
 
-    it('should return null if no port works', async () => {
-      mockRequest(https, undefined, new Error('Connection refused'))
-      mockRequest(http, undefined, new Error('Connection refused'))
-      
-      const result = await probeForConnectAPI([1234])
-      
-      expect(result).toBeNull()
-    })
-
-    it('should reject non-200 responses (like 404)', async () => {
-      // Non-200 responses should be rejected by the new Connect RPC prober
-      // HTTPS returns 404, HTTP returns 200 - should use HTTP
-      mockRequest(https, 404)
-      mockRequest(http, 200)
-      
-      const result = await probeForConnectAPI([1234])
-      
-      // HTTP 200 should be accepted
-      expect(result).toEqual({
-        baseUrl: 'http://localhost:1234',
-        protocol: 'http',
-        port: 1234
-      })
+    expect(result).toEqual({
+      baseUrl: 'https://127.0.0.1:3003',
+      protocol: 'https',
+      port: 3003
     })
   })
 })


### PR DESCRIPTION
## Summary
Windows follow-up patch for local mode endpoint detection.

This builds on top of the Linux fix branch used in PR #10 and addresses the separate Windows failure path reported in issue #9 comments.

## Why
Windows validation logs showed local mode could still fail after process detection due to endpoint/protocol selection issues:
- selecting a non-Connect endpoint
- HTTP/HTTPS mismatch on selected port

## Changes
- `src/local/process-detector.ts`
  - collect all Windows antigravity candidates and rank them instead of returning first match
  - prefer language-server / rpc-signaled candidates (`language_server`, `exa.language_server_pb`, `--csrf_token`, `--extension_server_port`)
  - deterministic selection with debug scoring logs

- `src/local/port-prober.ts`
  - strict Connect RPC probing for both HTTPS and HTTP using:
    - `/exa.language_server_pb.LanguageServerService/GetUnleashData`
  - accept Connect-like statuses `200` and `401`
  - reject protocol-mismatch body (`Client sent an HTTP request to an HTTPS server`)
  - stop accepting arbitrary HTTP `/` responses as valid endpoint signal

- tests
  - `test/local/process-detector.test.ts`: verifies Windows multi-candidate ranking
  - `test/local/port-prober.test.ts`: verifies strict endpoint/protocol behavior
  - `test/quota/service.test.ts`: verifies fallback to `extension_server_port` when PID port discovery is empty

## Validation
- `npm run typecheck` ✅
- `npm run build` ✅
- targeted tests:
  - `test/local/process-detector.test.ts` ✅
  - `test/local/port-prober.test.ts` ✅
  - `test/quota/service.test.ts` ✅
- full `npm test`: wakeup cron installer tests fail in this environment due to sandbox `spawnSync /bin/sh EPERM` (unrelated to changed modules)

## Request
@mwarden could you run one retest on Windows with:

```bash
antigravity-usage --debug --method local
```

and share logs if anything still fails?

Related: #9

